### PR TITLE
Abstracting the UI and API config

### DIFF
--- a/src/services/api.py
+++ b/src/services/api.py
@@ -11,7 +11,12 @@ import json
 app = Flask(__name__)
 api = Api(app)
 
-with open('../dev_config.json') as f:
+if 'DOODLE_CONFIG' in os.environ:
+    filepath = os.environ['DOODLE_CONFIG']
+else:
+    filepath = '../dev_config.json'
+
+with open(filepath) as f:
     config = json.load(f)
 
 client = pymongo.MongoClient(config.get("dbServerEndpoint"))

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -1,4 +1,6 @@
-from flask import Flask, render_template, url_for, flash, redirect, request
+from flask import Flask, render_template, url_for, flash, redirect, request\
+
+import os
 from ui import Forms
 import json
 import requests
@@ -8,9 +10,12 @@ app = Flask(__name__)
 
 app.config['SECRET_KEY'] = 'f9bf78b9a18ce6d46a0cd2b0b86df9da'
 
-#url = 'http://10.216.202.10:5000'
+if 'DOODLE_CONFIG' in os.environ:
+    filepath = os.environ['DOODLE_CONFIG']
+else:
+    filepath = '../dev_config.json'
 
-with open('../dev_config.json') as f:
+with open(filepath) as f:
     config = json.load(f)
 
 hostIp = config.get("hostIp")
@@ -23,9 +28,6 @@ def home():
     urlget = url+"/requirements"
     response = requests.get(urlget)
     col = response.json()
-    for branch in col:
-        for item in branch:
-            print("\'{}\': [\'{}\']".format(item, branch[item]))
 
     branches = []
 

--- a/src/ui/main.py
+++ b/src/ui/main.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, url_for, flash, redirect, request\
+from flask import Flask, render_template, url_for, flash, redirect, request
 
 import os
 from ui import Forms


### PR DESCRIPTION
Configures the UI and API to read the config filepath from the DOODLE_CONFIG environment variable. However if that does not exist it reads from ../dev_config.json

/ or \ may need to be changed for default depending on OS

to set the environment variable in ubuntu for pycharm:
vi ~/.profile
(could be bash_profile or bashrc instead of profile)
enter this line at the bottom
export DOODLE_CONFIG="<path to config file>"

